### PR TITLE
Added support for running the backend with just docker-compose up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,22 @@
-FROM ubuntu:24.04
+FROM golang:1.22.4 AS builder
+WORKDIR /app/build
+COPY go.mod ${WORKDIR}
+COPY go.sum ${WORKDIR}
+RUN go mod download && go mod verify 
 
+# Downloading Node now
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x -o nodesource_setup.sh
+RUN sh nodesource_setup.sh
+RUN apt-get install -y nodejs 
+RUN node -v && npm -v
+
+# Now create gullak.bin
+RUN npm install -g yarn
+COPY . .
+RUN make build
+
+
+FROM ubuntu:24.04
 # Update and install necessary packages
 RUN apt-get update && \
     apt-get install -y ca-certificates && \
@@ -14,10 +31,11 @@ USER appuser
 WORKDIR /app
 
 # Copy the binary
-COPY gullak.bin .
+COPY --from=builder /usr/local/bin/gullak.bin ./gullak.bin
 COPY config.sample.toml config.toml
 
 # Set the entrypoint
-EXPOSE 7777
-ENTRYPOINT ["./gullak.bin"]
+EXPOSE 3333
+RUN ls -lahtr
+ENTRYPOINT ["/app/gullak.bin"]
 CMD ["--config", "config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER appuser
 WORKDIR /app
 
 # Copy the binary
-COPY --from=builder /usr/local/bin/gullak.bin ./gullak.bin
+COPY --from=builder /app/build/bin/gullak.bin ./gullak.bin
 COPY config.sample.toml config.toml
 
 # Set the entrypoint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run
 
-BIN := /usr/local/bin/gullak.bin
+BIN := bin/gullak.bin
 
 LAST_COMMIT := $(shell git rev-parse --short HEAD)
 LAST_COMMIT_DATE := $(shell git show -s --format=%ci ${LAST_COMMIT})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run
 
-BIN := bin/gullak.bin
+BIN := /usr/local/bin/gullak.bin
 
 LAST_COMMIT := $(shell git rev-parse --short HEAD)
 LAST_COMMIT_DATE := $(shell git show -s --format=%ci ${LAST_COMMIT})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: "3.8"
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 3333:3333
+    depends_on:
+      - frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,3 @@ services:
       dockerfile: Dockerfile
     ports:
       - 3333:3333
-    depends_on:
-      - frontend

--- a/dockerignore.yml
+++ b/dockerignore.yml
@@ -1,0 +1,2 @@
+ui/*
+screenshots

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine3.20
+
+WORKDIR /app/ui
+
+ENV API_URL="http://localhost:3333"
+ENV UI_PORT=3334
+
+
+COPY . .
+RUN ["rm", "-rf", "package-lock.json"]
+RUN ["npm", "install"]
+
+EXPOSE ${UI_PORT}
+ENTRYPOINT [ "npm", "run", "dev"]
+
+


### PR DESCRIPTION
Now docker is used for everything, 

build : 
```
docker compose -f docker-compose.yml build
```

run : 
```
docker compose -f docker-compose.yml up 
```